### PR TITLE
IE11 Surface The dropdown list is displayed in wrong position

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1228,6 +1228,18 @@ the specific language governing permissions and limitations under the Apache Lic
             return (this.container) ? this.container.hasClass("select2-dropdown-open") : false;
         },
 
+		// abstract
+		calcExcludeHeight:function(){
+			var excludeHeight = 0;
+			if ($("body").outerHeight(false) > $("html").outerHeight(false) ||
+				Math.abs(document.body.getBoundingClientRect().top) === Math.abs(window.pageYOffset)) {
+				excludeHeight = 0;
+			} else {
+				excludeHeight = window.pageYOffset;
+			}
+			return excludeHeight;
+		},
+		
         // abstract
         positionDropdown: function() {
             var $dropdown = this.dropdown,
@@ -1241,7 +1253,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 windowHeight = $window.height(),
                 viewPortRight = $window.scrollLeft() + windowWidth,
                 viewportBottom = $window.scrollTop() + windowHeight,
-                dropTop = offset.top + height,
+                dropTop = offset.top + height - this.calcExcludeHeight(),
                 dropLeft = offset.left,
                 enoughRoomBelow = dropTop + dropHeight <= viewportBottom,
                 enoughRoomAbove = (offset.top - dropHeight) >= $window.scrollTop(),
@@ -2722,10 +2734,10 @@ the specific language governing permissions and limitations under the Apache Lic
                 .attr('for', this.search.attr('id'));
             this.opts.element.focus(this.bind(function () { this.focus(); }));
 
-            this.search.on("input paste", this.bind(function() {
+            this.search.on("input paste", this.bind(function(event) {
                 if (this.search.attr('placeholder') && this.search.val().length == 0) return;
                 if (!this.isInterfaceEnabled()) return;
-                if (!this.opened()) {
+                if (event.type === "input" && !this.opened()) {
                     this.open();
                 }
             }));


### PR DESCRIPTION
- Re-calculate the top of dropdown when the virtual keyboard is displayed.
- Fix when place holder is set back to input, IE fired an incorrect event that caused select2 opened dropdown list again.
